### PR TITLE
Add user mapping and fix hyperlinks (#1070)

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -1,112 +1,84 @@
 # DEPLOYMENTS
 ## Deployment 2.22
 
-:worm-vert-head-green:   
-:worm-vert-body-red: [24781ca](https://github.com/chrisguest75/git_examples/commit/24781ca)  Christopher Guest [ Add environment for issue tracking links  (#1022) (#2)](https://cnissues.atlassian.net/browse/LGH-1022)
-
-:worm-vert-body-blue: [dba5e28](https://github.com/chrisguest75/git_examples/commit/dba5e28)  Chris Guest [ Update release notes](https://cnissues.atlassian.net/browse/LGH-)
-
-:worm-vert-tail-red:
+:worm-vert-head-pink:   
+:worm-vert-body-grey: [24781ca](https://github.com/chrisguest75/git_examples/commit/24781ca) @chris.guest Add environment for issue tracking links  ([#1022](https://cnissues.atlassian.net/browse/LGH-1022)) (#2)   
+:worm-vert-body-blue: [dba5e28](https://github.com/chrisguest75/git_examples/commit/dba5e28) @chris.guest [](https://cnissues.atlassian.net/browse/LGH-)U[](https://cnissues.atlassian.net/browse/LGH-)p[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)   
+:worm-vert-tail-purple:
 
 ## Deployment 2.21
 
-:worm-vert-head-pink:   
-:worm-vert-body-white: [acf8d2b](https://github.com/chrisguest75/git_examples/commit/acf8d2b)  Chris Guest [ Fix line ending for head (#1055)](https://cnissues.atlassian.net/browse/LGH-1055)
-
-:worm-vert-body-red: [43267d0](https://github.com/chrisguest75/git_examples/commit/43267d0)  Chris Guest [ Update release notes](https://cnissues.atlassian.net/browse/LGH-)
-
-:worm-vert-tail-blue:
+:worm-vert-head-black:   
+:worm-vert-body-green: [acf8d2b](https://github.com/chrisguest75/git_examples/commit/acf8d2b) @chris.guest Fix line ending for head ([#1055](https://cnissues.atlassian.net/browse/LGH-1055))   
+:worm-vert-body-blue: [43267d0](https://github.com/chrisguest75/git_examples/commit/43267d0) @chris.guest [](https://cnissues.atlassian.net/browse/LGH-)U[](https://cnissues.atlassian.net/browse/LGH-)p[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)   
+:worm-vert-tail-pink:
 
 ## Deployment 2.20
 
-:worm-vert-head-grey:   
-:worm-vert-body-red: [5943833](https://github.com/chrisguest75/git_examples/commit/5943833)  Christopher Guest [ Work on a deployment list (#1054)](https://cnissues.atlassian.net/browse/LGH-1054)
-
-:worm-vert-body-pink: [e5c0e34](https://github.com/chrisguest75/git_examples/commit/e5c0e34)  Chris Guest [ Update release notes](https://cnissues.atlassian.net/browse/LGH-)
-
+:worm-vert-head-red:   
+:worm-vert-body-black: [5943833](https://github.com/chrisguest75/git_examples/commit/5943833) @chris.guest Work on a deployment list ([#1054](https://cnissues.atlassian.net/browse/LGH-1054))   
+:worm-vert-body-black: [e5c0e34](https://github.com/chrisguest75/git_examples/commit/e5c0e34) @chris.guest [](https://cnissues.atlassian.net/browse/LGH-)U[](https://cnissues.atlassian.net/browse/LGH-)p[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)   
 :worm-vert-tail-green:
 
 ## Deployment 2.17
 
-:worm-vert-head-blue:   
-:worm-vert-body-grey: [8de801d](https://github.com/chrisguest75/git_examples/commit/8de801d)  Chris Guest [ Fix output directory not being created - generate notes pre-merge (#1034)](https://cnissues.atlassian.net/browse/LGH-1034)
-
-:worm-vert-body-purple: [fe625ba](https://github.com/chrisguest75/git_examples/commit/fe625ba)  Chris Guest [ Fix output directory not being created - generate notes pre-merge (#1034)](https://cnissues.atlassian.net/browse/LGH-1034)
-
-:worm-vert-body-grey: [2e8e592](https://github.com/chrisguest75/git_examples/commit/2e8e592)  Chris Guest [ Merge branch master of github.com:chrisguest75/git_examples](https://cnissues.atlassian.net/browse/LGH-)
-
-:worm-vert-body-pink: [572a580](https://github.com/chrisguest75/git_examples/commit/572a580)  Christopher Guest [ Fix output directory not being created - generate notes pre-merge (#1034)](https://cnissues.atlassian.net/browse/LGH-1034)
-
-:worm-vert-body-grey: [d3d06db](https://github.com/chrisguest75/git_examples/commit/d3d06db)  Christopher Guest [ Fix bugs (#1)](https://cnissues.atlassian.net/browse/LGH-1)
-
+:worm-vert-head-pink:   
+:worm-vert-body-purple: [8de801d](https://github.com/chrisguest75/git_examples/commit/8de801d) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://cnissues.atlassian.net/browse/LGH-1034))   
+:worm-vert-body-blue: [fe625ba](https://github.com/chrisguest75/git_examples/commit/fe625ba) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://cnissues.atlassian.net/browse/LGH-1034))   
+:worm-vert-body-red: [2e8e592](https://github.com/chrisguest75/git_examples/commit/2e8e592) @chris.guest [](https://cnissues.atlassian.net/browse/LGH-)M[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)g[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)b[](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)h[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)m[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)f[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)g[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)h[](https://cnissues.atlassian.net/browse/LGH-)u[](https://cnissues.atlassian.net/browse/LGH-)b[](https://cnissues.atlassian.net/browse/LGH-).[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)m[](https://cnissues.atlassian.net/browse/LGH-):[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)h[](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)g[](https://cnissues.atlassian.net/browse/LGH-)u[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)7[](https://cnissues.atlassian.net/browse/LGH-)5[](https://cnissues.atlassian.net/browse/LGH-)/[](https://cnissues.atlassian.net/browse/LGH-)g[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)_[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)x[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)m[](https://cnissues.atlassian.net/browse/LGH-)p[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)   
+:worm-vert-body-pink: [572a580](https://github.com/chrisguest75/git_examples/commit/572a580) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://cnissues.atlassian.net/browse/LGH-1034))   
+:worm-vert-body-grey: [d3d06db](https://github.com/chrisguest75/git_examples/commit/d3d06db) @chris.guest Fix bugs ([#1](https://cnissues.atlassian.net/browse/LGH-1))   
 :worm-vert-tail-red:
 
 ## Deployment 2.2
 
-:worm-vert-head-white:   
-:worm-vert-body-blue: [ab4ffc5](https://github.com/chrisguest75/git_examples/commit/ab4ffc5)  Chris Guest [ Fix tables in markdown (#1023)](https://cnissues.atlassian.net/browse/LGH-1023)
-
-:worm-vert-body-white: [8cd97b7](https://github.com/chrisguest75/git_examples/commit/8cd97b7)  Chris Guest [ Update instructions (#1020)](https://cnissues.atlassian.net/browse/LGH-1020)
-
-:worm-vert-body-red: [41100cc](https://github.com/chrisguest75/git_examples/commit/41100cc)  Chris Guest [ Update release notes (#1017)](https://cnissues.atlassian.net/browse/LGH-1017)
-
-:worm-vert-tail-pink:
+:worm-vert-head-grey:   
+:worm-vert-body-pink: [ab4ffc5](https://github.com/chrisguest75/git_examples/commit/ab4ffc5) @chris.guest Fix tables in markdown ([#1023](https://cnissues.atlassian.net/browse/LGH-1023))   
+:worm-vert-body-blue: [8cd97b7](https://github.com/chrisguest75/git_examples/commit/8cd97b7) @chris.guest Update instructions ([#1020](https://cnissues.atlassian.net/browse/LGH-1020))   
+:worm-vert-body-brown: [41100cc](https://github.com/chrisguest75/git_examples/commit/41100cc) @chris.guest Update release notes ([#1017](https://cnissues.atlassian.net/browse/LGH-1017))   
+:worm-vert-tail-brown:
 
 ## Deployment 2.1
 
-:worm-vert-head-black:   
-:worm-vert-body-brown: [7130ef6](https://github.com/chrisguest75/git_examples/commit/7130ef6)  Chris Guest [ Reverse the order of the release notes (#1016)](https://cnissues.atlassian.net/browse/LGH-1016)
-
-:worm-vert-body-white: [910531e](https://github.com/chrisguest75/git_examples/commit/910531e)  Chris Guest [ Add more versions  (#1014)](https://cnissues.atlassian.net/browse/LGH-1014)
-
-:worm-vert-tail-brown:
+:worm-vert-head-grey:   
+:worm-vert-body-blue: [7130ef6](https://github.com/chrisguest75/git_examples/commit/7130ef6) @chris.guest Reverse the order of the release notes ([#1016](https://cnissues.atlassian.net/browse/LGH-1016))   
+:worm-vert-body-purple: [910531e](https://github.com/chrisguest75/git_examples/commit/910531e) @chris.guest Add more versions  ([#1014](https://cnissues.atlassian.net/browse/LGH-1014))   
+:worm-vert-tail-grey:
 
 ## Deployment 2.0
 
-:worm-vert-head-brown:   
-:worm-vert-body-black: [5144e24](https://github.com/chrisguest75/git_examples/commit/5144e24)  Chris Guest [ Add version to the release notes heading (#1013)](https://cnissues.atlassian.net/browse/LGH-1013)
-
-:worm-vert-body-red: [75d58ff](https://github.com/chrisguest75/git_examples/commit/75d58ff)  Chris Guest [ Add title to release notes (#include ticket)](https://cnissues.atlassian.net/browse/LGH-)
-
-:worm-vert-tail-purple:
+:worm-vert-head-pink:   
+:worm-vert-body-pink: [5144e24](https://github.com/chrisguest75/git_examples/commit/5144e24) @chris.guest Add version to the release notes heading ([#1013](https://cnissues.atlassian.net/browse/LGH-1013))   
+:worm-vert-body-red: [75d58ff](https://github.com/chrisguest75/git_examples/commit/75d58ff) @chris.guest [](https://cnissues.atlassian.net/browse/LGH-)A[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)([](https://cnissues.atlassian.net/browse/LGH-)#[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)u[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)k[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-))[](https://cnissues.atlassian.net/browse/LGH-)   
+:worm-vert-tail-blue:
 
 ## Deployment 1.3
 
-:worm-vert-head-blue:   
-:worm-vert-body-black: [58ee502](https://github.com/chrisguest75/git_examples/commit/58ee502)  Chris Guest [ Concatenate the outputs (#1011)](https://cnissues.atlassian.net/browse/LGH-1011)
-
-:worm-vert-body-blue: [44e2000](https://github.com/chrisguest75/git_examples/commit/44e2000)  Chris Guest [ Create all versions (#1010)](https://cnissues.atlassian.net/browse/LGH-1010)
-
-:worm-vert-body-black: [4ec980b](https://github.com/chrisguest75/git_examples/commit/4ec980b)  Chris Guest [ A working gomplate that iterates over commits (#1009)](https://cnissues.atlassian.net/browse/LGH-1009)
-
-:worm-vert-tail-white:
+:worm-vert-head-purple:   
+:worm-vert-body-purple: [58ee502](https://github.com/chrisguest75/git_examples/commit/58ee502) @chris.guest Concatenate the outputs ([#1011](https://cnissues.atlassian.net/browse/LGH-1011))   
+:worm-vert-body-white: [44e2000](https://github.com/chrisguest75/git_examples/commit/44e2000) @chris.guest Create all versions ([#1010](https://cnissues.atlassian.net/browse/LGH-1010))   
+:worm-vert-body-black: [4ec980b](https://github.com/chrisguest75/git_examples/commit/4ec980b) @chris.guest A working gomplate that iterates over commits ([#1009](https://cnissues.atlassian.net/browse/LGH-1009))   
+:worm-vert-tail-grey:
 
 ## Deployment 1.2
 
-:worm-vert-head-grey:   
-:worm-vert-body-brown: [acf1304](https://github.com/chrisguest75/git_examples/commit/acf1304)  Chris Guest [ Add amend instructions for commits (#1008)](https://cnissues.atlassian.net/browse/LGH-1008)
-
-:worm-vert-body-red: [0630898](https://github.com/chrisguest75/git_examples/commit/0630898)  Chris Guest [ Create a list in the gomplate (#1006)](https://cnissues.atlassian.net/browse/LGH-1006)
-
-:worm-vert-body-white: [44cb0b8](https://github.com/chrisguest75/git_examples/commit/44cb0b8)  Chris Guest [ Update the readme.md with example version structure (#1005)](https://cnissues.atlassian.net/browse/LGH-1005)
-
+:worm-vert-head-black:   
+:worm-vert-body-blue: [acf1304](https://github.com/chrisguest75/git_examples/commit/acf1304) @chris.guest Add amend instructions for commits ([#1008](https://cnissues.atlassian.net/browse/LGH-1008))   
+:worm-vert-body-red: [0630898](https://github.com/chrisguest75/git_examples/commit/0630898) @chris.guest Create a list in the gomplate ([#1006](https://cnissues.atlassian.net/browse/LGH-1006))   
+:worm-vert-body-brown: [44cb0b8](https://github.com/chrisguest75/git_examples/commit/44cb0b8) @chris.guest Update the readme.md with example version structure ([#1005](https://cnissues.atlassian.net/browse/LGH-1005))   
 :worm-vert-tail-brown:
 
 ## Deployment 1.1
 
-:worm-vert-head-grey:   
-:worm-vert-body-blue: [0ea7306](https://github.com/chrisguest75/git_examples/commit/0ea7306)  Chris Guest [ Update readme and add gitignore for output folder (#1004)](https://cnissues.atlassian.net/browse/LGH-1004)
-
-:worm-vert-body-red: [edaa811](https://github.com/chrisguest75/git_examples/commit/edaa811)  Chris Guest [ Update the readme for gomplate (#1003)](https://cnissues.atlassian.net/browse/LGH-1003)
-
-:worm-vert-tail-red:
+:worm-vert-head-pink:   
+:worm-vert-body-green: [0ea7306](https://github.com/chrisguest75/git_examples/commit/0ea7306) @chris.guest Update readme and add gitignore for output folder ([#1004](https://cnissues.atlassian.net/browse/LGH-1004))   
+:worm-vert-body-brown: [edaa811](https://github.com/chrisguest75/git_examples/commit/edaa811) @chris.guest Update the readme for gomplate ([#1003](https://cnissues.atlassian.net/browse/LGH-1003))   
+:worm-vert-tail-blue:
 
 ## Deployment 1.0
 
 :worm-vert-head-brown:   
-:worm-vert-body-purple: [ea5f6b1](https://github.com/chrisguest75/git_examples/commit/ea5f6b1)  Chris Guest [ Example table in markdown gomplate (#1003)](https://cnissues.atlassian.net/browse/LGH-1003)
-
-:worm-vert-body-grey: [592cb3e](https://github.com/chrisguest75/git_examples/commit/592cb3e)  Chris Guest [ Improve the format (#1002)](https://cnissues.atlassian.net/browse/LGH-1002)
-
-:worm-vert-tail-grey:
+:worm-vert-body-grey: [ea5f6b1](https://github.com/chrisguest75/git_examples/commit/ea5f6b1) @chris.guest Example table in markdown gomplate ([#1003](https://cnissues.atlassian.net/browse/LGH-1003))   
+:worm-vert-body-black: [592cb3e](https://github.com/chrisguest75/git_examples/commit/592cb3e) @chris.guest Improve the format ([#1002](https://cnissues.atlassian.net/browse/LGH-1002))   
+:worm-vert-tail-green:
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ Amending commits where you have forgot to add the ticket.
 ```
 git commit --amend
 ```
+
+## Debugging Templates Hint
+Clean the ./output directory and comment out all but one of the git log outputs.
+This makes the script run faster and allows quick testing of template modifications
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,93 +3,82 @@
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[24781ca](https://github.com/chrisguest75/git_examples/commit/24781ca) |  Christopher Guest | [ Add environment for issue tracking links  (#1022) (#2)](https://cnissues.atlassian.net/browse/LGH-1022) |
-|[dba5e28](https://github.com/chrisguest75/git_examples/commit/dba5e28) |  Chris Guest | [ Update release notes](https://cnissues.atlassian.net/browse/LGH-) |
-
+|[24781ca](https://github.com/chrisguest75/git_examples/commit/24781ca)|@chris.guest|Add environment for issue tracking links  ([#1022](https://cnissues.atlassian.net/browse/LGH-1022)) (#2)|
+|[dba5e28](https://github.com/chrisguest75/git_examples/commit/dba5e28)|@chris.guest|[](https://cnissues.atlassian.net/browse/LGH-)U[](https://cnissues.atlassian.net/browse/LGH-)p[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)|
 
 ## Version 2.21
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[acf8d2b](https://github.com/chrisguest75/git_examples/commit/acf8d2b) |  Chris Guest | [ Fix line ending for head (#1055)](https://cnissues.atlassian.net/browse/LGH-1055) |
-|[43267d0](https://github.com/chrisguest75/git_examples/commit/43267d0) |  Chris Guest | [ Update release notes](https://cnissues.atlassian.net/browse/LGH-) |
-
+|[acf8d2b](https://github.com/chrisguest75/git_examples/commit/acf8d2b)|@chris.guest|Fix line ending for head ([#1055](https://cnissues.atlassian.net/browse/LGH-1055))|
+|[43267d0](https://github.com/chrisguest75/git_examples/commit/43267d0)|@chris.guest|[](https://cnissues.atlassian.net/browse/LGH-)U[](https://cnissues.atlassian.net/browse/LGH-)p[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)|
 
 ## Version 2.20
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[5943833](https://github.com/chrisguest75/git_examples/commit/5943833) |  Christopher Guest | [ Work on a deployment list (#1054)](https://cnissues.atlassian.net/browse/LGH-1054) |
-|[e5c0e34](https://github.com/chrisguest75/git_examples/commit/e5c0e34) |  Chris Guest | [ Update release notes](https://cnissues.atlassian.net/browse/LGH-) |
-
+|[5943833](https://github.com/chrisguest75/git_examples/commit/5943833)|@chris.guest|Work on a deployment list ([#1054](https://cnissues.atlassian.net/browse/LGH-1054))|
+|[e5c0e34](https://github.com/chrisguest75/git_examples/commit/e5c0e34)|@chris.guest|[](https://cnissues.atlassian.net/browse/LGH-)U[](https://cnissues.atlassian.net/browse/LGH-)p[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)|
 
 ## Version 2.17
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[8de801d](https://github.com/chrisguest75/git_examples/commit/8de801d) |  Chris Guest | [ Fix output directory not being created - generate notes pre-merge (#1034)](https://cnissues.atlassian.net/browse/LGH-1034) |
-|[fe625ba](https://github.com/chrisguest75/git_examples/commit/fe625ba) |  Chris Guest | [ Fix output directory not being created - generate notes pre-merge (#1034)](https://cnissues.atlassian.net/browse/LGH-1034) |
-|[2e8e592](https://github.com/chrisguest75/git_examples/commit/2e8e592) |  Chris Guest | [ Merge branch master of github.com:chrisguest75/git_examples](https://cnissues.atlassian.net/browse/LGH-) |
-|[572a580](https://github.com/chrisguest75/git_examples/commit/572a580) |  Christopher Guest | [ Fix output directory not being created - generate notes pre-merge (#1034)](https://cnissues.atlassian.net/browse/LGH-1034) |
-|[d3d06db](https://github.com/chrisguest75/git_examples/commit/d3d06db) |  Christopher Guest | [ Fix bugs (#1)](https://cnissues.atlassian.net/browse/LGH-1) |
-
+|[8de801d](https://github.com/chrisguest75/git_examples/commit/8de801d)|@chris.guest|Fix output directory not being created - generate notes pre-merge ([#1034](https://cnissues.atlassian.net/browse/LGH-1034))|
+|[fe625ba](https://github.com/chrisguest75/git_examples/commit/fe625ba)|@chris.guest|Fix output directory not being created - generate notes pre-merge ([#1034](https://cnissues.atlassian.net/browse/LGH-1034))|
+|[2e8e592](https://github.com/chrisguest75/git_examples/commit/2e8e592)|@chris.guest|[](https://cnissues.atlassian.net/browse/LGH-)M[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)g[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)b[](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)h[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)m[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)f[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)g[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)h[](https://cnissues.atlassian.net/browse/LGH-)u[](https://cnissues.atlassian.net/browse/LGH-)b[](https://cnissues.atlassian.net/browse/LGH-).[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)m[](https://cnissues.atlassian.net/browse/LGH-):[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)h[](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)g[](https://cnissues.atlassian.net/browse/LGH-)u[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)7[](https://cnissues.atlassian.net/browse/LGH-)5[](https://cnissues.atlassian.net/browse/LGH-)/[](https://cnissues.atlassian.net/browse/LGH-)g[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)_[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)x[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)m[](https://cnissues.atlassian.net/browse/LGH-)p[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)|
+|[572a580](https://github.com/chrisguest75/git_examples/commit/572a580)|@chris.guest|Fix output directory not being created - generate notes pre-merge ([#1034](https://cnissues.atlassian.net/browse/LGH-1034))|
+|[d3d06db](https://github.com/chrisguest75/git_examples/commit/d3d06db)|@chris.guest|Fix bugs ([#1](https://cnissues.atlassian.net/browse/LGH-1))|
 
 ## Version 2.2
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[ab4ffc5](https://github.com/chrisguest75/git_examples/commit/ab4ffc5) |  Chris Guest | [ Fix tables in markdown (#1023)](https://cnissues.atlassian.net/browse/LGH-1023) |
-|[8cd97b7](https://github.com/chrisguest75/git_examples/commit/8cd97b7) |  Chris Guest | [ Update instructions (#1020)](https://cnissues.atlassian.net/browse/LGH-1020) |
-|[41100cc](https://github.com/chrisguest75/git_examples/commit/41100cc) |  Chris Guest | [ Update release notes (#1017)](https://cnissues.atlassian.net/browse/LGH-1017) |
-
+|[ab4ffc5](https://github.com/chrisguest75/git_examples/commit/ab4ffc5)|@chris.guest|Fix tables in markdown ([#1023](https://cnissues.atlassian.net/browse/LGH-1023))|
+|[8cd97b7](https://github.com/chrisguest75/git_examples/commit/8cd97b7)|@chris.guest|Update instructions ([#1020](https://cnissues.atlassian.net/browse/LGH-1020))|
+|[41100cc](https://github.com/chrisguest75/git_examples/commit/41100cc)|@chris.guest|Update release notes ([#1017](https://cnissues.atlassian.net/browse/LGH-1017))|
 
 ## Version 2.1
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[7130ef6](https://github.com/chrisguest75/git_examples/commit/7130ef6) |  Chris Guest | [ Reverse the order of the release notes (#1016)](https://cnissues.atlassian.net/browse/LGH-1016) |
-|[910531e](https://github.com/chrisguest75/git_examples/commit/910531e) |  Chris Guest | [ Add more versions  (#1014)](https://cnissues.atlassian.net/browse/LGH-1014) |
-
+|[7130ef6](https://github.com/chrisguest75/git_examples/commit/7130ef6)|@chris.guest|Reverse the order of the release notes ([#1016](https://cnissues.atlassian.net/browse/LGH-1016))|
+|[910531e](https://github.com/chrisguest75/git_examples/commit/910531e)|@chris.guest|Add more versions  ([#1014](https://cnissues.atlassian.net/browse/LGH-1014))|
 
 ## Version 2.0
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[5144e24](https://github.com/chrisguest75/git_examples/commit/5144e24) |  Chris Guest | [ Add version to the release notes heading (#1013)](https://cnissues.atlassian.net/browse/LGH-1013) |
-|[75d58ff](https://github.com/chrisguest75/git_examples/commit/75d58ff) |  Chris Guest | [ Add title to release notes (#include ticket)](https://cnissues.atlassian.net/browse/LGH-) |
-
+|[5144e24](https://github.com/chrisguest75/git_examples/commit/5144e24)|@chris.guest|Add version to the release notes heading ([#1013](https://cnissues.atlassian.net/browse/LGH-1013))|
+|[75d58ff](https://github.com/chrisguest75/git_examples/commit/75d58ff)|@chris.guest|[](https://cnissues.atlassian.net/browse/LGH-)A[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)r[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)a[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)o[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)s[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)([](https://cnissues.atlassian.net/browse/LGH-)#[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)n[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)l[](https://cnissues.atlassian.net/browse/LGH-)u[](https://cnissues.atlassian.net/browse/LGH-)d[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-) [](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-)i[](https://cnissues.atlassian.net/browse/LGH-)c[](https://cnissues.atlassian.net/browse/LGH-)k[](https://cnissues.atlassian.net/browse/LGH-)e[](https://cnissues.atlassian.net/browse/LGH-)t[](https://cnissues.atlassian.net/browse/LGH-))[](https://cnissues.atlassian.net/browse/LGH-)|
 
 ## Version 1.3
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[58ee502](https://github.com/chrisguest75/git_examples/commit/58ee502) |  Chris Guest | [ Concatenate the outputs (#1011)](https://cnissues.atlassian.net/browse/LGH-1011) |
-|[44e2000](https://github.com/chrisguest75/git_examples/commit/44e2000) |  Chris Guest | [ Create all versions (#1010)](https://cnissues.atlassian.net/browse/LGH-1010) |
-|[4ec980b](https://github.com/chrisguest75/git_examples/commit/4ec980b) |  Chris Guest | [ A working gomplate that iterates over commits (#1009)](https://cnissues.atlassian.net/browse/LGH-1009) |
-
+|[58ee502](https://github.com/chrisguest75/git_examples/commit/58ee502)|@chris.guest|Concatenate the outputs ([#1011](https://cnissues.atlassian.net/browse/LGH-1011))|
+|[44e2000](https://github.com/chrisguest75/git_examples/commit/44e2000)|@chris.guest|Create all versions ([#1010](https://cnissues.atlassian.net/browse/LGH-1010))|
+|[4ec980b](https://github.com/chrisguest75/git_examples/commit/4ec980b)|@chris.guest|A working gomplate that iterates over commits ([#1009](https://cnissues.atlassian.net/browse/LGH-1009))|
 
 ## Version 1.2
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[acf1304](https://github.com/chrisguest75/git_examples/commit/acf1304) |  Chris Guest | [ Add amend instructions for commits (#1008)](https://cnissues.atlassian.net/browse/LGH-1008) |
-|[0630898](https://github.com/chrisguest75/git_examples/commit/0630898) |  Chris Guest | [ Create a list in the gomplate (#1006)](https://cnissues.atlassian.net/browse/LGH-1006) |
-|[44cb0b8](https://github.com/chrisguest75/git_examples/commit/44cb0b8) |  Chris Guest | [ Update the readme.md with example version structure (#1005)](https://cnissues.atlassian.net/browse/LGH-1005) |
-
+|[acf1304](https://github.com/chrisguest75/git_examples/commit/acf1304)|@chris.guest|Add amend instructions for commits ([#1008](https://cnissues.atlassian.net/browse/LGH-1008))|
+|[0630898](https://github.com/chrisguest75/git_examples/commit/0630898)|@chris.guest|Create a list in the gomplate ([#1006](https://cnissues.atlassian.net/browse/LGH-1006))|
+|[44cb0b8](https://github.com/chrisguest75/git_examples/commit/44cb0b8)|@chris.guest|Update the readme.md with example version structure ([#1005](https://cnissues.atlassian.net/browse/LGH-1005))|
 
 ## Version 1.1
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[0ea7306](https://github.com/chrisguest75/git_examples/commit/0ea7306) |  Chris Guest | [ Update readme and add gitignore for output folder (#1004)](https://cnissues.atlassian.net/browse/LGH-1004) |
-|[edaa811](https://github.com/chrisguest75/git_examples/commit/edaa811) |  Chris Guest | [ Update the readme for gomplate (#1003)](https://cnissues.atlassian.net/browse/LGH-1003) |
-
+|[0ea7306](https://github.com/chrisguest75/git_examples/commit/0ea7306)|@chris.guest|Update readme and add gitignore for output folder ([#1004](https://cnissues.atlassian.net/browse/LGH-1004))|
+|[edaa811](https://github.com/chrisguest75/git_examples/commit/edaa811)|@chris.guest|Update the readme for gomplate ([#1003](https://cnissues.atlassian.net/browse/LGH-1003))|
 
 ## Version 1.0
 
 | CommitId      | Author        | Summary       |
 | ------------- | ------------- | ------------- |
-|[ea5f6b1](https://github.com/chrisguest75/git_examples/commit/ea5f6b1) |  Chris Guest | [ Example table in markdown gomplate (#1003)](https://cnissues.atlassian.net/browse/LGH-1003) |
-|[592cb3e](https://github.com/chrisguest75/git_examples/commit/592cb3e) |  Chris Guest | [ Improve the format (#1002)](https://cnissues.atlassian.net/browse/LGH-1002) |
-
+|[ea5f6b1](https://github.com/chrisguest75/git_examples/commit/ea5f6b1)|@chris.guest|Example table in markdown gomplate ([#1003](https://cnissues.atlassian.net/browse/LGH-1003))|
+|[592cb3e](https://github.com/chrisguest75/git_examples/commit/592cb3e)|@chris.guest|Improve the format ([#1002](https://cnissues.atlassian.net/browse/LGH-1002))|
 

--- a/deployed.gomplate
+++ b/deployed.gomplate
@@ -3,7 +3,16 @@
 :{{ (datasource "emojis").head }}-{{ (datasource "emojis").colours | random.Item }}:   
 {{ $lines := . -}}
 {{ range ($lines | csv) -}}
-:{{ (datasource "emojis").body }}-{{ (datasource "emojis").colours | random.Item }}: [{{ index . 0 | strings.ReplaceAll "'" "" }}]({{ (datasource "version").repo_url }}/commit/{{ index . 0 | strings.ReplaceAll "'" "" }}) {{ index . 1 | strings.ReplaceAll "'" "" }} [{{ index . 2 | strings.ReplaceAll "'" "" }}]({{ (datasource "version").issues_url }}{{ regexp.Find "(#)([0-9]{1,4})" (index . 2) | strings.ReplaceAll "#" "" }})
-
+{{- $worm := (print (datasource "emojis").body "-" ((datasource "emojis").colours | random.Item)) -}}
+{{- $commitid := (index . 0 | strings.ReplaceAll "'" "") -}}
+{{- $commiturl := (print (datasource "version").repo_url "/commit/" $commitid) -}}
+{{- $author := (index . 1 | strings.ReplaceAll "'" "" | strings.Trim " ") -}}
+{{- $authorremap := (index (datasource "users").users $author) -}}
+{{- $subject := (index . 2 | strings.ReplaceAll "'" "" | strings.Trim " ") -}}
+{{- $issueid := regexp.Find "(#)([0-9]{1,4})" (index . 2) -}}
+{{- $issueurl :=  print (datasource "version").issues_url ($issueid | strings.ReplaceAll "#" "") -}}
+{{- $issuehyperlink :=  print "[" $issueid "](" $issueurl ")" -}}
+{{- $hyperlinkedsubject := ($subject | strings.ReplaceAll $issueid $issuehyperlink) -}}
+{{ print ":" $worm ":" }} [{{ print $commitid }}]({{ print $commiturl }}) {{ print $authorremap }} {{ print $hyperlinkedsubject }}   
 {{ end }}:{{ (datasource "emojis").tail }}-{{ (datasource "emojis").colours | random.Item }}:
 

--- a/generate_release.sh
+++ b/generate_release.sh
@@ -3,7 +3,10 @@
 if [[ -f .env ]];then
     echo "* Sourcing local .env"
     . .env
+else
+    echo "Warning no local .env found"
 fi
+
 if [[ -z $1 ]]; then 
     echo "Usage: generate_release.sh release|deployment"    
     exit 1
@@ -49,6 +52,7 @@ if [[ $1 == "release" ]]; then
         version=$(basename ${filename} .txt)
         echo "{'version':'${version}', 'repo_url':'${REPO_URL}', 'issues_url':'${ISSUE_TRACKING_URL}'}" | \
             gomplate --file ${TEMPLATE} \
+            -c users=user_mapping.json \
             -c version=stdin:///in.json \
             -c .=${filename} > ./output/${version}.md  
     done
@@ -68,6 +72,7 @@ elif [[ $1 == "deployment" ]]; then
         echo "{'version':'${version}', 'repo_url':'${REPO_URL}', 'issues_url':'${ISSUE_TRACKING_URL}'}" | \
             gomplate --file ${TEMPLATE} \
             -c emojis=deployment_emojis.json \
+            -c users=user_mapping.json \
             -c version=stdin:///in.json \
             -c .=${filename} > ./output/${version}.md  
     done

--- a/release_notes.gomplate
+++ b/release_notes.gomplate
@@ -4,7 +4,14 @@
 | ------------- | ------------- | ------------- |
 {{ $lines := . -}}
 {{ range ($lines | csv) -}}
-
-|[{{ index . 0 | strings.ReplaceAll "'" "" }}]({{ (datasource "version").repo_url }}/commit/{{ index . 0 | strings.ReplaceAll "'" "" }}) | {{ index . 1 | strings.ReplaceAll "'" "" }} | [{{ index . 2 | strings.ReplaceAll "'" "" }}]({{ (datasource "version").issues_url }}{{ regexp.Find "(#)([0-9]{1,4})" (index . 2) | strings.ReplaceAll "#" "" }}) |
+{{- $commitid := (index . 0 | strings.ReplaceAll "'" "") -}}
+{{- $commiturl := (print (datasource "version").repo_url "/commit/" $commitid) -}}
+{{- $author := (index . 1 | strings.ReplaceAll "'" "" | strings.Trim " ") -}}
+{{- $authorremap := (index (datasource "users").users $author) -}}
+{{- $subject := (index . 2 | strings.ReplaceAll "'" "" | strings.Trim " ") -}}
+{{- $issueid := regexp.Find "(#)([0-9]{1,4})" (index . 2) -}}
+{{- $issueurl :=  print (datasource "version").issues_url ($issueid | strings.ReplaceAll "#" "") -}}
+{{- $issuehyperlink :=  print "[" $issueid "](" $issueurl ")" -}}
+{{- $hyperlinkedsubject := ($subject | strings.ReplaceAll $issueid $issuehyperlink) -}}
+|[{{ print $commitid }}]({{ print $commiturl }})|{{ print $authorremap }}|{{ print $hyperlinkedsubject }}|
 {{ end }}
-

--- a/user_mapping.json
+++ b/user_mapping.json
@@ -1,0 +1,6 @@
+{
+      "users": {
+            "Chris Guest":"@chris.guest",
+            "Christopher Guest":"@chris.guest"
+      }
+}


### PR DESCRIPTION
Problem
User names could not be posted to slack and hyperlinks were bdly formatted

Solution
Broke out the processing into individual commands.