### PR TITLE
Allow adding of extra metadata (#1267)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,4 @@ ISSUE_TRACKING_URL=https://github.com/chrisguest75/git_examples/issues/
 REPO_URL=https://github.com/chrisguest75/git_examples
 SLACK_POST=https://hooks.slack.com/services/TOKEN
 SLACK_CHANNEL=\#channel_name
+METADATA="Environment: PROD\nDeploynent:distoless\nWorkflow:machine_build\nRepo:git_examples"

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -1,129 +1,129 @@
 # DEPLOYMENTS
 ## Deployment 3.4
 
-:worm-vert-head-black:
-:worm-vert-body-brown: [c67ef63](https://github.com/chrisguest75/git_examples/commit/c67ef63) @chris.guest Fix the code for tags changes  add --no-pager ([#1200](https://github.com/chrisguest75/git_examples/issues/1200)) ([#1029](https://github.com/chrisguest75/git_examples/issues/1029))   
-:worm-vert-body-white: [45cd975](https://github.com/chrisguest75/git_examples/commit/45cd975) @chris.guest Add slack export to post to slack ([#1250](https://github.com/chrisguest75/git_examples/issues/1250))   
-:worm-vert-body-white: [a674972](https://github.com/chrisguest75/git_examples/commit/a674972) @chris.guest Add slack export to post to slack ([#1250](https://github.com/chrisguest75/git_examples/issues/1250))   
-:worm-vert-body-blue: [d70f41a](https://github.com/chrisguest75/git_examples/commit/d70f41a) @chris.guest Update release   
+:worm-vert-head-brown:
+:worm-vert-body-red: [c67ef63](https://github.com/chrisguest75/git_examples/commit/c67ef63) @chris.guest Fix the code for tags changes  add --no-pager ([#1200](https://github.com/chrisguest75/git_examples/issues/1200)) ([#1029](https://github.com/chrisguest75/git_examples/issues/1029))   
+:worm-vert-body-purple: [45cd975](https://github.com/chrisguest75/git_examples/commit/45cd975) @chris.guest Add slack export to post to slack ([#1250](https://github.com/chrisguest75/git_examples/issues/1250))   
+:worm-vert-body-green: [a674972](https://github.com/chrisguest75/git_examples/commit/a674972) @chris.guest Add slack export to post to slack ([#1250](https://github.com/chrisguest75/git_examples/issues/1250))   
+:worm-vert-body-white: [d70f41a](https://github.com/chrisguest75/git_examples/commit/d70f41a) @chris.guest Update release   
 :worm-vert-tail-green:
 
 ## Deployment 3.3
 
-:worm-vert-head-grey:
-:worm-vert-body-green: [f0b2f1f](https://github.com/chrisguest75/git_examples/commit/f0b2f1f) @chris.guest Demonstrate the release process ([#1114](https://github.com/chrisguest75/git_examples/issues/1114))   
-:worm-vert-body-pink: [558b0ec](https://github.com/chrisguest75/git_examples/commit/558b0ec) @chris.guest Update release notes and readme   
-:worm-vert-tail-black:
+:worm-vert-head-white:
+:worm-vert-body-brown: [f0b2f1f](https://github.com/chrisguest75/git_examples/commit/f0b2f1f) @chris.guest Demonstrate the release process ([#1114](https://github.com/chrisguest75/git_examples/issues/1114))   
+:worm-vert-body-white: [558b0ec](https://github.com/chrisguest75/git_examples/commit/558b0ec) @chris.guest Update release notes and readme   
+:worm-vert-tail-grey:
 
 ## Deployment 3.2
 
-:worm-vert-head-green:
-:worm-vert-body-pink: [43ac9b1](https://github.com/chrisguest75/git_examples/commit/43ac9b1) @chris.guest Add a ranges file and a tags version ([#1110](https://github.com/chrisguest75/git_examples/issues/1110)) ([#1111](https://github.com/chrisguest75/git_examples/issues/1111)) ([#1112](https://github.com/chrisguest75/git_examples/issues/1112))   
-:worm-vert-body-purple: [e62c7ae](https://github.com/chrisguest75/git_examples/commit/e62c7ae) @chris.guest Update release notes and readme.   
-:worm-vert-tail-pink:
+:worm-vert-head-grey:
+:worm-vert-body-red: [43ac9b1](https://github.com/chrisguest75/git_examples/commit/43ac9b1) @chris.guest Add a ranges file and a tags version ([#1110](https://github.com/chrisguest75/git_examples/issues/1110)) ([#1111](https://github.com/chrisguest75/git_examples/issues/1111)) ([#1112](https://github.com/chrisguest75/git_examples/issues/1112))   
+:worm-vert-body-blue: [e62c7ae](https://github.com/chrisguest75/git_examples/commit/e62c7ae) @chris.guest Update release notes and readme.   
+:worm-vert-tail-red:
 
 ## Deployment 3.1
 
-:worm-vert-head-blue:
-:worm-vert-body-black: [25b9955](https://github.com/chrisguest75/git_examples/commit/25b9955) @chris.guest Refactor ([#6](https://github.com/chrisguest75/git_examples/issues/6))   
-:worm-vert-body-blue: [902a586](https://github.com/chrisguest75/git_examples/commit/902a586) @chris.guest Update release notes.   
-:worm-vert-tail-green:
+:worm-vert-head-brown:
+:worm-vert-body-grey: [25b9955](https://github.com/chrisguest75/git_examples/commit/25b9955) @chris.guest Refactor ([#6](https://github.com/chrisguest75/git_examples/issues/6))   
+:worm-vert-body-grey: [902a586](https://github.com/chrisguest75/git_examples/commit/902a586) @chris.guest Update release notes.   
+:worm-vert-tail-white:
 
 ## Deployment 3.0
 
-:worm-vert-head-purple:
-:worm-vert-body-white: [6e6b77c](https://github.com/chrisguest75/git_examples/commit/6e6b77c) @chris.guest Fix multi issue subject lines with hyperlinks ([#1078](https://github.com/chrisguest75/git_examples/issues/1078))   
-:worm-vert-body-purple: [3945396](https://github.com/chrisguest75/git_examples/commit/3945396) @chris.guest Add user mapping and fix hyperlinks ([#1070](https://github.com/chrisguest75/git_examples/issues/1070)) ([#4](https://github.com/chrisguest75/git_examples/issues/4))   
-:worm-vert-body-brown: [94e963e](https://github.com/chrisguest75/git_examples/commit/94e963e) @chris.guest New release notes   
-:worm-vert-body-black: [99b5962](https://github.com/chrisguest75/git_examples/commit/99b5962) @chris.guest Update release notes   
-:worm-vert-tail-purple:
+:worm-vert-head-white:
+:worm-vert-body-black: [6e6b77c](https://github.com/chrisguest75/git_examples/commit/6e6b77c) @chris.guest Fix multi issue subject lines with hyperlinks ([#1078](https://github.com/chrisguest75/git_examples/issues/1078))   
+:worm-vert-body-black: [3945396](https://github.com/chrisguest75/git_examples/commit/3945396) @chris.guest Add user mapping and fix hyperlinks ([#1070](https://github.com/chrisguest75/git_examples/issues/1070)) ([#4](https://github.com/chrisguest75/git_examples/issues/4))   
+:worm-vert-body-grey: [94e963e](https://github.com/chrisguest75/git_examples/commit/94e963e) @chris.guest New release notes   
+:worm-vert-body-brown: [99b5962](https://github.com/chrisguest75/git_examples/commit/99b5962) @chris.guest Update release notes   
+:worm-vert-tail-blue:
 
 ## Deployment 2.22
 
-:worm-vert-head-red:
-:worm-vert-body-purple: [24781ca](https://github.com/chrisguest75/git_examples/commit/24781ca) @chris.guest Add environment for issue tracking links  ([#1022](https://github.com/chrisguest75/git_examples/issues/1022)) ([#2](https://github.com/chrisguest75/git_examples/issues/2))   
-:worm-vert-body-red: [dba5e28](https://github.com/chrisguest75/git_examples/commit/dba5e28) @chris.guest Update release notes   
-:worm-vert-tail-purple:
+:worm-vert-head-brown:
+:worm-vert-body-blue: [24781ca](https://github.com/chrisguest75/git_examples/commit/24781ca) @chris.guest Add environment for issue tracking links  ([#1022](https://github.com/chrisguest75/git_examples/issues/1022)) ([#2](https://github.com/chrisguest75/git_examples/issues/2))   
+:worm-vert-body-black: [dba5e28](https://github.com/chrisguest75/git_examples/commit/dba5e28) @chris.guest Update release notes   
+:worm-vert-tail-grey:
 
 ## Deployment 2.21
 
-:worm-vert-head-black:
-:worm-vert-body-black: [acf8d2b](https://github.com/chrisguest75/git_examples/commit/acf8d2b) @chris.guest Fix line ending for head ([#1055](https://github.com/chrisguest75/git_examples/issues/1055))   
-:worm-vert-body-brown: [43267d0](https://github.com/chrisguest75/git_examples/commit/43267d0) @chris.guest Update release notes   
-:worm-vert-tail-purple:
+:worm-vert-head-grey:
+:worm-vert-body-red: [acf8d2b](https://github.com/chrisguest75/git_examples/commit/acf8d2b) @chris.guest Fix line ending for head ([#1055](https://github.com/chrisguest75/git_examples/issues/1055))   
+:worm-vert-body-red: [43267d0](https://github.com/chrisguest75/git_examples/commit/43267d0) @chris.guest Update release notes   
+:worm-vert-tail-blue:
 
 ## Deployment 2.20
 
-:worm-vert-head-brown:
-:worm-vert-body-pink: [5943833](https://github.com/chrisguest75/git_examples/commit/5943833) @chris.guest Work on a deployment list ([#1054](https://github.com/chrisguest75/git_examples/issues/1054))   
-:worm-vert-body-green: [e5c0e34](https://github.com/chrisguest75/git_examples/commit/e5c0e34) @chris.guest Update release notes   
-:worm-vert-tail-green:
+:worm-vert-head-black:
+:worm-vert-body-grey: [5943833](https://github.com/chrisguest75/git_examples/commit/5943833) @chris.guest Work on a deployment list ([#1054](https://github.com/chrisguest75/git_examples/issues/1054))   
+:worm-vert-body-purple: [e5c0e34](https://github.com/chrisguest75/git_examples/commit/e5c0e34) @chris.guest Update release notes   
+:worm-vert-tail-black:
 
 ## Deployment 2.17
 
-:worm-vert-head-red:
-:worm-vert-body-white: [8de801d](https://github.com/chrisguest75/git_examples/commit/8de801d) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://github.com/chrisguest75/git_examples/issues/1034))   
-:worm-vert-body-purple: [fe625ba](https://github.com/chrisguest75/git_examples/commit/fe625ba) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://github.com/chrisguest75/git_examples/issues/1034))   
-:worm-vert-body-white: [2e8e592](https://github.com/chrisguest75/git_examples/commit/2e8e592) @chris.guest Merge branch master of github.com:chrisguest75/git_examples   
-:worm-vert-body-pink: [572a580](https://github.com/chrisguest75/git_examples/commit/572a580) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://github.com/chrisguest75/git_examples/issues/1034))   
-:worm-vert-body-pink: [d3d06db](https://github.com/chrisguest75/git_examples/commit/d3d06db) @chris.guest Fix bugs ([#1](https://github.com/chrisguest75/git_examples/issues/1))   
-:worm-vert-tail-green:
+:worm-vert-head-black:
+:worm-vert-body-brown: [8de801d](https://github.com/chrisguest75/git_examples/commit/8de801d) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://github.com/chrisguest75/git_examples/issues/1034))   
+:worm-vert-body-pink: [fe625ba](https://github.com/chrisguest75/git_examples/commit/fe625ba) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://github.com/chrisguest75/git_examples/issues/1034))   
+:worm-vert-body-black: [2e8e592](https://github.com/chrisguest75/git_examples/commit/2e8e592) @chris.guest Merge branch master of github.com:chrisguest75/git_examples   
+:worm-vert-body-brown: [572a580](https://github.com/chrisguest75/git_examples/commit/572a580) @chris.guest Fix output directory not being created - generate notes pre-merge ([#1034](https://github.com/chrisguest75/git_examples/issues/1034))   
+:worm-vert-body-blue: [d3d06db](https://github.com/chrisguest75/git_examples/commit/d3d06db) @chris.guest Fix bugs ([#1](https://github.com/chrisguest75/git_examples/issues/1))   
+:worm-vert-tail-black:
 
 ## Deployment 2.2
 
-:worm-vert-head-purple:
-:worm-vert-body-green: [ab4ffc5](https://github.com/chrisguest75/git_examples/commit/ab4ffc5) @chris.guest Fix tables in markdown ([#1023](https://github.com/chrisguest75/git_examples/issues/1023))   
-:worm-vert-body-green: [8cd97b7](https://github.com/chrisguest75/git_examples/commit/8cd97b7) @chris.guest Update instructions ([#1020](https://github.com/chrisguest75/git_examples/issues/1020))   
+:worm-vert-head-grey:
+:worm-vert-body-red: [ab4ffc5](https://github.com/chrisguest75/git_examples/commit/ab4ffc5) @chris.guest Fix tables in markdown ([#1023](https://github.com/chrisguest75/git_examples/issues/1023))   
+:worm-vert-body-pink: [8cd97b7](https://github.com/chrisguest75/git_examples/commit/8cd97b7) @chris.guest Update instructions ([#1020](https://github.com/chrisguest75/git_examples/issues/1020))   
 :worm-vert-body-purple: [41100cc](https://github.com/chrisguest75/git_examples/commit/41100cc) @chris.guest Update release notes ([#1017](https://github.com/chrisguest75/git_examples/issues/1017))   
-:worm-vert-tail-brown:
+:worm-vert-tail-white:
 
 ## Deployment 2.1
 
-:worm-vert-head-brown:
-:worm-vert-body-blue: [7130ef6](https://github.com/chrisguest75/git_examples/commit/7130ef6) @chris.guest Reverse the order of the release notes ([#1016](https://github.com/chrisguest75/git_examples/issues/1016))   
-:worm-vert-body-red: [910531e](https://github.com/chrisguest75/git_examples/commit/910531e) @chris.guest Add more versions  ([#1014](https://github.com/chrisguest75/git_examples/issues/1014))   
-:worm-vert-tail-white:
+:worm-vert-head-blue:
+:worm-vert-body-grey: [7130ef6](https://github.com/chrisguest75/git_examples/commit/7130ef6) @chris.guest Reverse the order of the release notes ([#1016](https://github.com/chrisguest75/git_examples/issues/1016))   
+:worm-vert-body-blue: [910531e](https://github.com/chrisguest75/git_examples/commit/910531e) @chris.guest Add more versions  ([#1014](https://github.com/chrisguest75/git_examples/issues/1014))   
+:worm-vert-tail-black:
 
 ## Deployment 2.0
 
-:worm-vert-head-green:
-:worm-vert-body-pink: [5144e24](https://github.com/chrisguest75/git_examples/commit/5144e24) @chris.guest Add version to the release notes heading ([#1013](https://github.com/chrisguest75/git_examples/issues/1013))   
-:worm-vert-body-purple: [75d58ff](https://github.com/chrisguest75/git_examples/commit/75d58ff) @chris.guest Add title to release notes (#include ticket)   
-:worm-vert-tail-brown:
+:worm-vert-head-white:
+:worm-vert-body-green: [5144e24](https://github.com/chrisguest75/git_examples/commit/5144e24) @chris.guest Add version to the release notes heading ([#1013](https://github.com/chrisguest75/git_examples/issues/1013))   
+:worm-vert-body-red: [75d58ff](https://github.com/chrisguest75/git_examples/commit/75d58ff) @chris.guest Add title to release notes (#include ticket)   
+:worm-vert-tail-purple:
 
 ## Deployment 1.3
 
-:worm-vert-head-blue:
-:worm-vert-body-pink: [58ee502](https://github.com/chrisguest75/git_examples/commit/58ee502) @chris.guest Concatenate the outputs ([#1011](https://github.com/chrisguest75/git_examples/issues/1011))   
-:worm-vert-body-grey: [44e2000](https://github.com/chrisguest75/git_examples/commit/44e2000) @chris.guest Create all versions ([#1010](https://github.com/chrisguest75/git_examples/issues/1010))   
-:worm-vert-body-pink: [4ec980b](https://github.com/chrisguest75/git_examples/commit/4ec980b) @chris.guest A working gomplate that iterates over commits ([#1009](https://github.com/chrisguest75/git_examples/issues/1009))   
-:worm-vert-tail-white:
+:worm-vert-head-purple:
+:worm-vert-body-red: [58ee502](https://github.com/chrisguest75/git_examples/commit/58ee502) @chris.guest Concatenate the outputs ([#1011](https://github.com/chrisguest75/git_examples/issues/1011))   
+:worm-vert-body-purple: [44e2000](https://github.com/chrisguest75/git_examples/commit/44e2000) @chris.guest Create all versions ([#1010](https://github.com/chrisguest75/git_examples/issues/1010))   
+:worm-vert-body-red: [4ec980b](https://github.com/chrisguest75/git_examples/commit/4ec980b) @chris.guest A working gomplate that iterates over commits ([#1009](https://github.com/chrisguest75/git_examples/issues/1009))   
+:worm-vert-tail-black:
 
 ## Deployment 1.2
 
-:worm-vert-head-black:
-:worm-vert-body-green: [acf1304](https://github.com/chrisguest75/git_examples/commit/acf1304) @chris.guest Add amend instructions for commits ([#1008](https://github.com/chrisguest75/git_examples/issues/1008))   
-:worm-vert-body-green: [0630898](https://github.com/chrisguest75/git_examples/commit/0630898) @chris.guest Create a list in the gomplate ([#1006](https://github.com/chrisguest75/git_examples/issues/1006))   
-:worm-vert-body-green: [44cb0b8](https://github.com/chrisguest75/git_examples/commit/44cb0b8) @chris.guest Update the readme.md with example version structure ([#1005](https://github.com/chrisguest75/git_examples/issues/1005))   
-:worm-vert-tail-red:
+:worm-vert-head-blue:
+:worm-vert-body-white: [acf1304](https://github.com/chrisguest75/git_examples/commit/acf1304) @chris.guest Add amend instructions for commits ([#1008](https://github.com/chrisguest75/git_examples/issues/1008))   
+:worm-vert-body-red: [0630898](https://github.com/chrisguest75/git_examples/commit/0630898) @chris.guest Create a list in the gomplate ([#1006](https://github.com/chrisguest75/git_examples/issues/1006))   
+:worm-vert-body-red: [44cb0b8](https://github.com/chrisguest75/git_examples/commit/44cb0b8) @chris.guest Update the readme.md with example version structure ([#1005](https://github.com/chrisguest75/git_examples/issues/1005))   
+:worm-vert-tail-black:
 
 ## Deployment 1.1
 
-:worm-vert-head-brown:
+:worm-vert-head-purple:
 :worm-vert-body-grey: [0ea7306](https://github.com/chrisguest75/git_examples/commit/0ea7306) @chris.guest Update readme and add gitignore for output folder ([#1004](https://github.com/chrisguest75/git_examples/issues/1004))   
-:worm-vert-body-red: [edaa811](https://github.com/chrisguest75/git_examples/commit/edaa811) @chris.guest Update the readme for gomplate ([#1003](https://github.com/chrisguest75/git_examples/issues/1003))   
-:worm-vert-tail-blue:
+:worm-vert-body-black: [edaa811](https://github.com/chrisguest75/git_examples/commit/edaa811) @chris.guest Update the readme for gomplate ([#1003](https://github.com/chrisguest75/git_examples/issues/1003))   
+:worm-vert-tail-white:
 
 ## Deployment 1.0
 
-:worm-vert-head-grey:
-:worm-vert-body-purple: [ea5f6b1](https://github.com/chrisguest75/git_examples/commit/ea5f6b1) @chris.guest Example table in markdown gomplate ([#1003](https://github.com/chrisguest75/git_examples/issues/1003))   
-:worm-vert-body-brown: [592cb3e](https://github.com/chrisguest75/git_examples/commit/592cb3e) @chris.guest Improve the format ([#1002](https://github.com/chrisguest75/git_examples/issues/1002))   
-:worm-vert-tail-green:
+:worm-vert-head-white:
+:worm-vert-body-pink: [ea5f6b1](https://github.com/chrisguest75/git_examples/commit/ea5f6b1) @chris.guest Example table in markdown gomplate ([#1003](https://github.com/chrisguest75/git_examples/issues/1003))   
+:worm-vert-body-pink: [592cb3e](https://github.com/chrisguest75/git_examples/commit/592cb3e) @chris.guest Improve the format ([#1002](https://github.com/chrisguest75/git_examples/issues/1002))   
+:worm-vert-tail-grey:
 
 ## Deployment 0.0
 
-:worm-vert-head-red:
-:worm-vert-body-white: [162856a](https://github.com/chrisguest75/git_examples/commit/162856a) @chris.guest A first test commit Ticket [#1001](https://github.com/chrisguest75/git_examples/issues/1001) Problem Im testing out the gitmessage   
+:worm-vert-head-blue:
+:worm-vert-body-grey: [162856a](https://github.com/chrisguest75/git_examples/commit/162856a) @chris.guest A first test commit Ticket [#1001](https://github.com/chrisguest75/git_examples/issues/1001) Problem Im testing out the gitmessage   
 :worm-vert-tail-pink:
 

--- a/generate.sh
+++ b/generate.sh
@@ -211,7 +211,8 @@ function main() {
                         echo "* Building version markdown in ${TEMPORARY_FOLDER}"
                         for filename in ${TEMPORARY_FOLDER}*.txt; do
                             version=$(basename ${filename} .txt)
-                            echo "{'version':'${version}', 'repo_url':'${REPO_URL}', 'issues_url':'${ISSUE_TRACKING_URL}', 'channel':'${SLACK_CHANNEL}', 'seperator':'${SEPERATOR}', 'issue_prefix':'${ISSUE_PREFIX}'}" | \
+                            echo "${version}"
+                            echo "{'version':'${version}', 'repo_url':'${REPO_URL}', 'issues_url':'${ISSUE_TRACKING_URL}', 'channel':'${SLACK_CHANNEL}', 'seperator':'${SEPERATOR}', 'issue_prefix':'${ISSUE_PREFIX}', 'metadata':'${METADATA}'}" | \
                                 gomplate --file ${TEMPLATE} \
                                 -c emojis=deployment_emojis.json \
                                 -c users=user_mapping.json \

--- a/slack.gomplate
+++ b/slack.gomplate
@@ -36,6 +36,16 @@
 {
   "channel": "{{ (datasource "version").channel }}",
   "blocks": [
+    {{- $metadata := (datasource "version").metadata -}}
+    {{- if $metadata -}}
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "{{ print $metadata}}"
+      }
+    },
+    {{- end -}}
     {
       "type": "section",
       "text": {


### PR DESCRIPTION
Problem
In CI we need to be able to distinguish different deployments

Solution
Allow a metadata section to be passed through and render in the slack message.